### PR TITLE
Feat/include unity player so

### DIFF
--- a/u2deb
+++ b/u2deb
@@ -502,13 +502,13 @@ EOF
   if [ -d "$builddir/x86" ] ; then
     echo "hard link files to build/x86... "
     mkdir -p "$builddir/x86/source"
-    cp -vrl "$sourcedir/${name}_Data" "$sourcedir/${name}.x86" "$builddir/x86/source"
+    cp -vrl "$sourcedir/${name}_Data" "$sourcedir/${name}.x86" "$sourcedir/UnityPlayer.so" "$builddir/x86/source"
     echo "done"
   fi
   if [ -d "$builddir/x86_64" ] ; then
     echo "hard link files to build/x86_64..."
     mkdir -p "$builddir/x86_64/source"
-    cp -vrl "$sourcedir/${name}_Data" "$sourcedir/${name}.x86_64" "$builddir/x86_64/source"
+    cp -vrl "$sourcedir/${name}_Data" "$sourcedir/${name}.x86_64" "$sourcedir/UnityPlayer.so" "$builddir/x86_64/source"
     echo "done"
   fi
   if [ -d "$builddir/x86" ] && [ -d "$builddir/x86_64" ] ; then

--- a/u2deb
+++ b/u2deb
@@ -502,13 +502,19 @@ EOF
   if [ -d "$builddir/x86" ] ; then
     echo "hard link files to build/x86... "
     mkdir -p "$builddir/x86/source"
-    cp -vrl "$sourcedir/${name}_Data" "$sourcedir/${name}.x86" "$sourcedir/UnityPlayer.so" "$builddir/x86/source"
+    cp -vrl "$sourcedir/${name}_Data" "$sourcedir/${name}.x86" "$builddir/x86/source"
+    if [ -f "$sourcedir/UnityPlayer.so" ] ; then
+      cp -vrl "$sourcedir/UnityPlayer.so" "$builddir/x86/source"
+    fi
     echo "done"
   fi
   if [ -d "$builddir/x86_64" ] ; then
     echo "hard link files to build/x86_64..."
     mkdir -p "$builddir/x86_64/source"
-    cp -vrl "$sourcedir/${name}_Data" "$sourcedir/${name}.x86_64" "$sourcedir/UnityPlayer.so" "$builddir/x86_64/source"
+    cp -vrl "$sourcedir/${name}_Data" "$sourcedir/${name}.x86_64" "$builddir/x86_64/source"
+    if [ -f "$sourcedir/UnityPlayer.so" ] ; then
+      cp -vrl "$sourcedir/UnityPlayer.so" "$builddir/x86_64/source"
+    fi
     echo "done"
   fi
   if [ -d "$builddir/x86" ] && [ -d "$builddir/x86_64" ] ; then


### PR DESCRIPTION
Since previous version of `u2deb` doesn't include `UnityPlayer.so` in `.deb` file, the installed unity program doesn't start.
This pull request fixes this issue.